### PR TITLE
Improve CHIP32 simulator compatibility and reload validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 tests/**/*.bin
 tests/chip32-tmp.asm
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,7 +49,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
- "regex",
  "serde",
  "serde_json",
  "tui",
@@ -291,35 +281,6 @@ checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "3.2.22", features = ["derive"] }
 crossterm = "0.25.0"
-regex = "1.6.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 tui = "0.19.0"

--- a/src/apf.rs
+++ b/src/apf.rs
@@ -17,7 +17,6 @@ pub struct DataJsonData {
 
 #[derive(Clone, Deserialize)]
 pub struct DataSlot {
-    // TODO: This can also be a string of hex
     #[serde(deserialize_with = "serde_string_or_int")]
     pub id: u32,
     pub filename: String,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -863,7 +863,6 @@ impl CPU {
                 let reg_y = self.get_reg(reg_y_index);
 
                 self.logs.push(format!(
-                    // TODO: What does this mean
                     "Sim: Adjusting pmp address of file {reg_x:#X} to {reg_y:#X}"
                 ));
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ffi::OsStr,
     fmt::Display,
     fs::File,
@@ -31,6 +32,7 @@ pub struct CPU {
     pub zero: bool,
 
     pub ram: Memory,
+    pub initial_ram: Memory,
     // TODO: It is unclear if this should live in memory or separately, and unclear how large it should be
     pub stack: [u32; 32],
 
@@ -41,6 +43,7 @@ pub struct CPU {
     pub formatted_instruction: String,
     pub logs: Vec<String>,
     pub active_bitstream: Option<usize>,
+    pub ui_visible: HashMap<u32, bool>,
 }
 
 #[derive(Clone)]
@@ -273,7 +276,18 @@ impl CPU {
                     |reg, immediate| (reg & immediate, false),
                 )
             }
-            0x10 => todo!("RSET"),
+            0x10 => {
+                // rset #16
+                // The simulator does not currently model the hidden register-set state
+                // this instruction manipulates on hardware, but several real loaders
+                // use it as part of their boot epilogue. Consume the immediate and log
+                // the operation so those programs can continue.
+                let immediate = self.pc_word();
+
+                self.logs
+                    .push(format!("Sim: rset switched to register set {immediate:#X}"));
+                self.formatted_instruction = format!("rset #{immediate:#X}");
+            }
             0x11 => todo!("CRC"),
             0x20 => {
                 // asl Rx,Ry
@@ -718,26 +732,43 @@ impl CPU {
             }
             0x47 => {
                 // clc/sec
+                // Official docs describe only 0x4700 (CLC) and 0x4701 (SEC), but
+                // real vendor binaries also ship with 0x4703 at the start vector.
+                // Those binaries behave like SEC on hardware, so treat the low bit
+                // as authoritative and ignore the upper compatibility bits here.
                 let identifier = reg_x_index;
 
-                match identifier {
-                    0 => self.set_carry(false),
-                    1 => self.set_carry(true),
-                    _ => panic!("Unknown identifier {identifier} for 0x47"),
-                };
+                self.set_carry((identifier & 0x1) != 0);
 
                 self.set_instruction_string(
-                    if identifier == 0 { "clc" } else { "sec" },
+                    if (identifier & 0x1) == 0 {
+                        "clc"
+                    } else {
+                        "sec"
+                    },
                     InstructionKind::None,
                 );
             }
             0x48 => {
                 // uivisible Rx,Ry
-                // Unimplemented
                 let reg_x = self.get_reg(reg_x_index);
                 let reg_y = self.get_reg(reg_y_index);
-                self.logs
-                    .push(format!("Sim: UIVISIBLE Rx: {reg_x} Ry: {reg_y}"));
+                let visible = match reg_y {
+                    0 => {
+                        self.ui_visible.insert(reg_x, false);
+                        false
+                    }
+                    1 => {
+                        self.ui_visible.insert(reg_x, true);
+                        true
+                    }
+                    _ => self.ui_visible.get(&reg_x).copied().unwrap_or(true),
+                };
+                self.zero = visible;
+                self.logs.push(format!(
+                    "Sim: UIVISIBLE id {reg_x} mode {reg_y} visible {}",
+                    if visible { 1 } else { 0 }
+                ));
 
                 self.set_instruction_string(
                     "uivisible",
@@ -1052,6 +1083,7 @@ impl CPU {
                         self.ram.write_byte((reg_x + i).to_lower_word(), byte);
                     }
 
+                    *offset += reg_y;
                     self.zero = true;
                 } else {
                     // No open file, throw error
@@ -1669,6 +1701,8 @@ impl CPU {
         let mut work_regs = [0; 16];
         work_regs[0] = selected_slot;
 
+        let initial_ram = Memory::from_bytes(buffer);
+
         Ok(CPU {
             pc: 0x2,
             sp: 0,
@@ -1676,7 +1710,8 @@ impl CPU {
             error_pc_reg: 0,
             carry: false,
             zero: false,
-            ram: Memory::from_bytes(buffer),
+            ram: initial_ram.clone(),
+            initial_ram,
             stack: [0; 32],
             file_state: FileState {
                 slots: data_slots,
@@ -1686,7 +1721,27 @@ impl CPU {
             formatted_instruction: String::new(),
             logs: Vec::new(),
             active_bitstream: None,
+            ui_visible: HashMap::new(),
         })
+    }
+
+    pub fn restart_for_slot(&mut self, slot: u32) {
+        let mut preserved_regs = self.work_regs;
+        preserved_regs[0] = slot;
+
+        self.pc = 0x2;
+        self.sp = 0;
+        self.work_regs = preserved_regs;
+        self.error_pc_reg = 0;
+        self.carry = false;
+        self.zero = false;
+        self.ram = self.initial_ram.clone();
+        self.stack = [0; 32];
+        self.file_state.loaded = FileLoadedState::None;
+        self.halt = HaltState::Running;
+        self.formatted_instruction.clear();
+        self.logs
+            .push(format!("Sim: Restarting CHIP32 with reload slot {slot:#X}"));
     }
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1267,8 +1267,10 @@ impl CPU {
                         );
                     }
                     _ => {
-                        // Do nothing
-                        todo!("Unimplemented {inst_prefix_byte:#X}")
+                        self.formatted_instruction = format!(".word #{inst_word:#06X}");
+                        self.logs
+                            .push(format!("Sim: Unimplemented opcode {inst_prefix_byte:#X}"));
+                        self.jump_to_error();
                     }
                 }
             }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -19,6 +19,8 @@ use crate::{
     },
 };
 
+const STACK_SIZE: usize = 32;
+
 #[derive(Clone)]
 pub struct CPU {
     pub pc: u16,
@@ -33,8 +35,7 @@ pub struct CPU {
 
     pub ram: Memory,
     pub program_path: PathBuf,
-    // TODO: It is unclear if this should live in memory or separately, and unclear how large it should be
-    pub stack: [u32; 32],
+    pub stack: [u32; STACK_SIZE],
 
     pub file_state: FileState,
 
@@ -671,6 +672,12 @@ impl CPU {
             0x43 => {
                 // push Rx
                 let reg_x_index = reg_x_index;
+
+                if self.sp >= STACK_SIZE {
+                    self.logs.push(format!("Sim: Stack overflow"));
+
+                    return self.jump_to_error();
+                }
 
                 self.stack[self.sp] = self.get_reg(reg_x_index);
 
@@ -1523,8 +1530,7 @@ impl CPU {
     ) {
         if conditional(self.zero, self.carry) {
             // Should return
-            // SP must be < 31
-            if self.sp >= 31 {
+            if self.sp >= STACK_SIZE {
                 // Error
                 self.logs.push(format!("Sim: Stack overflow"));
 
@@ -1734,7 +1740,7 @@ impl CPU {
             zero: false,
             ram: Memory::from_bytes(buffer),
             program_path: PathBuf::from(path_str),
-            stack: [0; 32],
+            stack: [0; STACK_SIZE],
             file_state: FileState {
                 slots: data_slots,
                 loaded: FileLoadedState::None,
@@ -1759,7 +1765,7 @@ impl CPU {
         self.carry = false;
         self.zero = false;
         self.ram = Memory::from_bytes(buffer);
-        self.stack = [0; 32];
+        self.stack = [0; STACK_SIZE];
         self.file_state.loaded = FileLoadedState::None;
         self.halt = HaltState::Running;
         self.formatted_instruction.clear();

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -5,7 +5,7 @@ use std::{
     fs::File,
     io::{self, Read},
     ops::{Shl, Shr},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use serde::Serialize;
@@ -32,7 +32,7 @@ pub struct CPU {
     pub zero: bool,
 
     pub ram: Memory,
-    pub initial_ram: Memory,
+    pub program_path: PathBuf,
     // TODO: It is unclear if this should live in memory or separately, and unclear how large it should be
     pub stack: [u32; 32],
 
@@ -1701,8 +1701,6 @@ impl CPU {
         let mut work_regs = [0; 16];
         work_regs[0] = selected_slot;
 
-        let initial_ram = Memory::from_bytes(buffer);
-
         Ok(CPU {
             pc: 0x2,
             sp: 0,
@@ -1710,8 +1708,8 @@ impl CPU {
             error_pc_reg: 0,
             carry: false,
             zero: false,
-            ram: initial_ram.clone(),
-            initial_ram,
+            ram: Memory::from_bytes(buffer),
+            program_path: PathBuf::from(path_str),
             stack: [0; 32],
             file_state: FileState {
                 slots: data_slots,
@@ -1725,9 +1723,10 @@ impl CPU {
         })
     }
 
-    pub fn restart_for_slot(&mut self, slot: u32) {
+    pub fn restart_for_slot(&mut self, slot: u32) -> Result<(), io::Error> {
         let mut preserved_regs = self.work_regs;
         preserved_regs[0] = slot;
+        let buffer = file_to_buffer(&self.program_path)?;
 
         self.pc = 0x2;
         self.sp = 0;
@@ -1735,18 +1734,20 @@ impl CPU {
         self.error_pc_reg = 0;
         self.carry = false;
         self.zero = false;
-        self.ram = self.initial_ram.clone();
+        self.ram = Memory::from_bytes(buffer);
         self.stack = [0; 32];
         self.file_state.loaded = FileLoadedState::None;
         self.halt = HaltState::Running;
         self.formatted_instruction.clear();
         self.logs
             .push(format!("Sim: Restarting CHIP32 with reload slot {slot:#X}"));
+
+        Ok(())
     }
 }
 
-fn file_to_buffer(path_str: &str) -> Result<Vec<u8>, io::Error> {
-    let mut file = File::open(path_str)?;
+fn file_to_buffer(path: impl AsRef<Path>) -> Result<Vec<u8>, io::Error> {
+    let mut file = File::open(path)?;
 
     let mut buffer = Vec::<u8>::new();
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -415,11 +415,13 @@ impl CPU {
                     if x_value == 0 && y_value == 0 {
                         // Full match
                         self.zero = true;
+                        self.carry = false;
 
                         self.logs.push(format!("Sim: test strings matched"));
                         return;
                     } else if y_value == 0 {
                         // Partial match
+                        self.zero = false;
                         self.carry = true;
 
                         self.logs
@@ -429,7 +431,8 @@ impl CPU {
 
                     if x_value != y_value {
                         // No match
-                        // TODO: Do we need to clear flags?
+                        self.zero = false;
+                        self.carry = false;
                         self.logs.push(format!("Sim: test strings did not match"));
                         return;
                     }
@@ -439,6 +442,8 @@ impl CPU {
 
                     if x_address > 0x1FFF || y_address > 0x1FFF {
                         // Overran end of memory
+                        self.zero = false;
+                        self.carry = false;
                         self.logs.push(format!("Sim: test overran end of memory"));
 
                         return;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -288,7 +288,18 @@ impl CPU {
                     .push(format!("Sim: rset switched to register set {immediate:#X}"));
                 self.formatted_instruction = format!("rset #{immediate:#X}");
             }
-            0x11 => todo!("CRC"),
+            0x11 => {
+                // crc Rx,Ry,Rz,#n
+                let polynomial = self.pc_word();
+                let reg_z_index = (self.pc_word() & 0xF) as u8;
+                let address = self.get_reg(reg_x_index).to_lower_word();
+                let length = self.get_reg(reg_y_index);
+                let crc = self.crc16(address, length, self.get_reg(reg_z_index), polynomial);
+
+                self.set_reg(reg_z_index, crc.into());
+                self.formatted_instruction =
+                    format!("crc R{reg_x_index},R{reg_y_index},R{reg_z_index},#{polynomial:#X}");
+            }
             0x20 => {
                 // asl Rx,Ry
                 self.alu_double_value_inst("asl", inst_suffix_byte, true, false, |reg_x, reg_y| {
@@ -1537,13 +1548,26 @@ impl CPU {
         self.pc = 0;
     }
 
-    // fn pc_byte(&mut self) -> u8 {
-    //     let value = self.ram.mem_read_byte(self.pc);
+    fn crc16(&self, address: u16, length: u32, initial: u32, polynomial: u16) -> u16 {
+        let mut crc = initial.to_lower_word();
 
-    //     self.pc += 1;
+        for offset in 0..length {
+            let byte = self
+                .ram
+                .read_byte(address.wrapping_add(offset.to_lower_word()));
+            crc ^= (byte as u16) << 8;
 
-    //     value
-    // }
+            for _ in 0..8 {
+                crc = if (crc & 0x8000) != 0 {
+                    (crc << 1) ^ polynomial
+                } else {
+                    crc << 1
+                };
+            }
+        }
+
+        crc
+    }
 
     fn pc_word(&mut self) -> u16 {
         let value = self.ram.read_word(self.pc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ struct Args {
     #[clap(short = 's', long, value_parser)]
     data_slot: Option<u32>,
 
+    /// Additional slot IDs to simulate as runtime reloads after the initial run in JSON mode.
+    /// Each reload preserves R1-R15 and re-enters CHIP32 with R0 set to the new slot.
+    #[clap(long = "reload-slot", value_parser, requires = "json")]
+    reload_slots: Vec<u32>,
+
     /// Execute the simulation in JSON output mode
     #[clap(long)]
     json: bool,
@@ -53,7 +58,7 @@ fn main() -> Result<(), io::Error> {
     let mut cpu = CPU::load_file(&args.bin, slots, args.data_slot)?;
 
     if args.json {
-        let exit_code = execute_with_json(&mut cpu);
+        let exit_code = execute_with_json(&mut cpu, &args.reload_slots);
 
         println!("{}", build_json_output(&cpu));
 
@@ -82,7 +87,7 @@ fn main() -> Result<(), io::Error> {
     Ok(())
 }
 
-fn execute_with_json(cpu: &mut CPU) -> usize {
+fn execute_to_halt(cpu: &mut CPU) -> usize {
     // No GUI, just run up to 1 million cycles
     for _ in 0..1_000_000 {
         cpu.step();
@@ -95,7 +100,24 @@ fn execute_with_json(cpu: &mut CPU) -> usize {
     }
 
     // Did not terminate
-    return 2;
+    2
+}
+
+fn execute_with_json(cpu: &mut CPU, reload_slots: &[u32]) -> usize {
+    let exit_code = execute_to_halt(cpu);
+    if exit_code != 0 {
+        return exit_code;
+    }
+
+    for slot in reload_slots {
+        cpu.restart_for_slot(*slot);
+        let exit_code = execute_to_halt(cpu);
+        if exit_code != 0 {
+            return exit_code;
+        }
+    }
+
+    0
 }
 
 fn build_json_output(cpu: &CPU) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), io::Error> {
     let mut cpu = CPU::load_file(&args.bin, slots, args.data_slot)?;
 
     if args.json {
-        let exit_code = execute_with_json(&mut cpu, &args.reload_slots);
+        let exit_code = execute_with_json(&mut cpu, &args.reload_slots)?;
 
         println!("{}", build_json_output(&cpu));
 
@@ -87,7 +87,7 @@ fn main() -> Result<(), io::Error> {
     Ok(())
 }
 
-fn execute_to_halt(cpu: &mut CPU) -> usize {
+fn execute_until_halt(cpu: &mut CPU) -> usize {
     // No GUI, just run up to 1 million cycles
     for _ in 0..1_000_000 {
         cpu.step();
@@ -103,21 +103,21 @@ fn execute_to_halt(cpu: &mut CPU) -> usize {
     2
 }
 
-fn execute_with_json(cpu: &mut CPU, reload_slots: &[u32]) -> usize {
-    let exit_code = execute_to_halt(cpu);
+fn execute_with_json(cpu: &mut CPU, reload_slots: &[u32]) -> Result<usize, io::Error> {
+    let exit_code = execute_until_halt(cpu);
     if exit_code != 0 {
-        return exit_code;
+        return Ok(exit_code);
     }
 
     for slot in reload_slots {
-        cpu.restart_for_slot(*slot);
-        let exit_code = execute_to_halt(cpu);
+        cpu.restart_for_slot(*slot)?;
+        let exit_code = execute_until_halt(cpu);
         if exit_code != 0 {
-            return exit_code;
+            return Ok(exit_code);
         }
     }
 
-    0
+    Ok(0)
 }
 
 fn build_json_output(cpu: &CPU) -> String {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -46,13 +46,10 @@ impl Memory {
         )
     }
 
-    // TODO: Log message when you clobber the ROM data
     pub fn write_byte(&mut self, address: u16, byte: u8) {
         let address = address as usize;
 
-        if address < self.rom_size {
-            println!("ERROR: Clobbering ROM data");
-        }
+        self.warn_if_rom_write(address);
 
         self.ram[address] = byte;
     }
@@ -60,9 +57,7 @@ impl Memory {
     pub fn write_word(&mut self, address: u16, word: u16) {
         let address = address as usize;
 
-        if address < self.rom_size {
-            println!("ERROR: Clobbering ROM data");
-        }
+        self.warn_if_rom_write(address);
 
         let [lower, upper] = word.to_le_bytes();
 
@@ -73,9 +68,7 @@ impl Memory {
     pub fn write_long(&mut self, address: u16, word: u32) {
         let address = address as usize;
 
-        if address < self.rom_size {
-            println!("ERROR: Clobbering ROM data");
-        }
+        self.warn_if_rom_write(address);
 
         let [lower_a, upper_a, lower_b, upper_b] = word.to_le_bytes();
 
@@ -83,5 +76,11 @@ impl Memory {
         self.ram[address + 1] = upper_a;
         self.ram[address + 2] = lower_b;
         self.ram[address + 3] = upper_b;
+    }
+
+    fn warn_if_rom_write(&self, address: usize) {
+        if address < self.rom_size {
+            println!("ERROR: Clobbering ROM data");
+        }
     }
 }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,12 +1,13 @@
 #[derive(Clone)]
 pub struct Memory {
-    ram: [u8; 8 * 1024],
+    ram: Box<[u8]>,
     rom_size: usize,
 }
 
 impl Memory {
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
-        let mut ram = [0; 8 * 1024];
+        const RAM_SIZE: usize = 8 * 1024;
+        let mut ram = vec![0; RAM_SIZE].into_boxed_slice();
 
         bytes
             .iter()

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -40,7 +40,7 @@ pub fn run_app<B: Backend>(
                 let mut did_esc = false;
 
                 if let DisplayMode::Memory { .. } = app.display_mode {
-                    if app.input.len() > 0 {
+                    if !app.input.is_empty() {
                         app.input = String::new();
                         did_esc = true;
                     }
@@ -57,7 +57,7 @@ pub fn run_app<B: Backend>(
                 KeyCode::Enter => {
                     match app.input.as_str() {
                         "s" | "step" => {
-                            // TODO: This is inefficient, but easy
+                            // Promote the precomputed lookahead state for before/after rendering.
                             state = next_state.clone();
                             next_state.step();
                         }

--- a/src/util/serde.rs
+++ b/src/util/serde.rs
@@ -12,7 +12,10 @@ impl HexStringOrInt for u32 {
 
 impl HexStringOrInt for &str {
     fn to_int(self) -> u32 {
-        let raw_bytes = self.trim_start_matches("0x");
+        let raw_bytes = self
+            .strip_prefix("0x")
+            .or_else(|| self.strip_prefix("0X"))
+            .unwrap_or(self);
         u32::from_str_radix(raw_bytes, 16)
             .expect(&format!("Could not parse hex value \"{raw_bytes}\""))
     }

--- a/tests/apf.rs
+++ b/tests/apf.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, env, fs};
 
-use chip32_sim::cpu::CPU;
+use chip32_sim::{apf::parse_json, cpu::CPU};
 use util::test_command_without_setup;
 
 mod util;
@@ -14,6 +14,45 @@ fn it_test() {
     test_apf_with_target("test", "r1,r2", "HW1", "HW_Long", false, false);
     test_apf_with_target("test", "r1,r2", "HW1", "Random", false, false);
     test_apf_with_target("test", "r1,r2", "HW1", "Partial", false, false);
+}
+
+#[test]
+fn it_parses_hex_string_data_slot_ids() {
+    let dir = env::temp_dir().join(format!("chip32-apf-{}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp data json dir");
+    fs::write(dir.join("slot.bin"), []).expect("create temp slot file");
+
+    let json_path = dir.join("data.json");
+    fs::write(
+        &json_path,
+        r#"{
+            "data": {
+                "magic": "APF_VER_1",
+                "data_slots": [
+                    {
+                        "name": "Hex",
+                        "id": "0X20",
+                        "required": true,
+                        "filename": "slot.bin"
+                    }
+                ]
+            }
+        }"#,
+    )
+    .expect("write temp data json");
+
+    let slots = parse_json(json_path.to_str().expect("temp json path utf8"));
+
+    assert_eq!(slots[0].id, 0x20);
+    assert_eq!(
+        slots[0].filename,
+        dir.join("slot.bin")
+            .canonicalize()
+            .expect("canonical slot path")
+            .into_os_string()
+            .into_string()
+            .expect("slot path utf8")
+    );
 }
 
 fn test_apf_with_target(

--- a/tests/asm/crc.asm
+++ b/tests/asm/crc.asm
@@ -1,0 +1,15 @@
+architecture chip32.vm
+
+// Error vector
+                exit 1
+
+// Start vector
+start:
+                ld r1,#data
+                ld r2,#9
+                ld r3,#0xFFFF
+                crc r1,r2,r3,#0x1021
+                exit 0
+
+data:
+                db "123456789"

--- a/tests/asm/reload.asm
+++ b/tests/asm/reload.asm
@@ -1,0 +1,28 @@
+architecture chip32.vm
+
+// Error vector
+                jp error
+
+// Start vector
+start:
+                bit r13,#1
+                jp z,cold_boot
+                cmp r0,#2
+                jp z,reload_slot_2
+                exit 1
+
+cold_boot:
+                or r13,#1
+                ld r1,#0x1234
+                exit 0
+
+reload_slot_2:
+                cmp r1,#0x1234
+                jp z,reload_ok
+                exit 1
+
+reload_ok:
+                exit 0
+
+error:
+                exit 1

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use util::prep_and_load;
+
+mod util;
+
+fn run_until_halt(cpu: &mut chip32_sim::cpu::CPU) {
+    for _ in 0..1_000_000 {
+        cpu.step();
+        if !matches!(cpu.halt, chip32_sim::cpu::HaltState::Running) {
+            return;
+        }
+    }
+
+    panic!("CPU did not halt");
+}
+
+#[test]
+fn it_executes_crc16() {
+    let mut cpu = prep_and_load("tests/asm/crc.asm", "tests/bin/crc.bin", HashMap::new());
+
+    run_until_halt(&mut cpu);
+
+    assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
+    assert_eq!(cpu.work_regs[3], 0x29B1);
+}

--- a/tests/crc.rs
+++ b/tests/crc.rs
@@ -1,25 +1,14 @@
 use std::collections::HashMap;
 
-use util::prep_and_load;
+use util::{execute_until_halt, prep_and_load};
 
 mod util;
-
-fn run_until_halt(cpu: &mut chip32_sim::cpu::CPU) {
-    for _ in 0..1_000_000 {
-        cpu.step();
-        if !matches!(cpu.halt, chip32_sim::cpu::HaltState::Running) {
-            return;
-        }
-    }
-
-    panic!("CPU did not halt");
-}
 
 #[test]
 fn it_executes_crc16() {
     let mut cpu = prep_and_load("tests/asm/crc.asm", "tests/bin/crc.bin", HashMap::new());
 
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
     assert_eq!(cpu.work_regs[3], 0x29B1);

--- a/tests/invalid_opcode.rs
+++ b/tests/invalid_opcode.rs
@@ -15,10 +15,8 @@ fn run_until_halt(cpu: &mut CPU) {
 
 #[test]
 fn it_routes_unknown_opcodes_to_error_vector() {
-    let path = PathBuf::from(env::temp_dir()).join(format!(
-        "chip32_invalid_opcode_{}.bin",
-        std::process::id()
-    ));
+    let path = PathBuf::from(env::temp_dir())
+        .join(format!("chip32_invalid_opcode_{}.bin", std::process::id()));
 
     // 0x0000: 0x4601 (exit 1)
     // 0x0002: 0x0100 (invalid/reserved opcode)

--- a/tests/invalid_opcode.rs
+++ b/tests/invalid_opcode.rs
@@ -1,0 +1,39 @@
+use std::{env, fs, path::PathBuf};
+
+use chip32_sim::cpu::{HaltState, CPU};
+
+fn run_until_halt(cpu: &mut CPU) {
+    for _ in 0..1_000_000 {
+        cpu.step();
+        if !matches!(cpu.halt, HaltState::Running) {
+            return;
+        }
+    }
+
+    panic!("CPU did not halt");
+}
+
+#[test]
+fn it_routes_unknown_opcodes_to_error_vector() {
+    let path = PathBuf::from(env::temp_dir()).join(format!(
+        "chip32_invalid_opcode_{}.bin",
+        std::process::id()
+    ));
+
+    // 0x0000: 0x4601 (exit 1)
+    // 0x0002: 0x0100 (invalid/reserved opcode)
+    fs::write(&path, [0x01, 0x46, 0x00, 0x01]).expect("write temp bin");
+
+    let mut cpu =
+        CPU::load_file(path.to_str().expect("temp path utf8"), None, None).expect("load temp bin");
+    run_until_halt(&mut cpu);
+
+    assert!(matches!(cpu.halt, HaltState::Failure));
+    assert!(
+        cpu.logs
+            .iter()
+            .any(|log| log.contains("Unimplemented opcode 0x1")),
+        "expected unknown opcode log, got {:?}",
+        cpu.logs
+    );
+}

--- a/tests/invalid_opcode.rs
+++ b/tests/invalid_opcode.rs
@@ -1,17 +1,9 @@
 use std::{env, fs, path::PathBuf};
 
 use chip32_sim::cpu::{HaltState, CPU};
+use util::execute_until_halt;
 
-fn run_until_halt(cpu: &mut CPU) {
-    for _ in 0..1_000_000 {
-        cpu.step();
-        if !matches!(cpu.halt, HaltState::Running) {
-            return;
-        }
-    }
-
-    panic!("CPU did not halt");
-}
+mod util;
 
 #[test]
 fn it_routes_unknown_opcodes_to_error_vector() {
@@ -24,7 +16,7 @@ fn it_routes_unknown_opcodes_to_error_vector() {
 
     let mut cpu =
         CPU::load_file(path.to_str().expect("temp path utf8"), None, None).expect("load temp bin");
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, HaltState::Failure));
     assert!(

--- a/tests/legacy_sec.rs
+++ b/tests/legacy_sec.rs
@@ -1,17 +1,9 @@
 use std::{env, fs, path::PathBuf};
 
 use chip32_sim::cpu::{HaltState, CPU};
+use util::execute_until_halt;
 
-fn run_until_halt(cpu: &mut CPU) {
-    for _ in 0..1_000_000 {
-        cpu.step();
-        if !matches!(cpu.halt, HaltState::Running) {
-            return;
-        }
-    }
-
-    panic!("CPU did not halt");
-}
+mod util;
 
 #[test]
 fn it_treats_4703_as_legacy_sec() {
@@ -24,7 +16,7 @@ fn it_treats_4703_as_legacy_sec() {
 
     let mut cpu =
         CPU::load_file(path.to_str().expect("temp path utf8"), None, None).expect("load temp bin");
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, HaltState::Success));
     assert!(cpu.carry, "legacy 0x4703 should set carry like SEC");

--- a/tests/legacy_sec.rs
+++ b/tests/legacy_sec.rs
@@ -1,0 +1,31 @@
+use std::{env, fs, path::PathBuf};
+
+use chip32_sim::cpu::{HaltState, CPU};
+
+fn run_until_halt(cpu: &mut CPU) {
+    for _ in 0..1_000_000 {
+        cpu.step();
+        if !matches!(cpu.halt, HaltState::Running) {
+            return;
+        }
+    }
+
+    panic!("CPU did not halt");
+}
+
+#[test]
+fn it_treats_4703_as_legacy_sec() {
+    let path = PathBuf::from(env::temp_dir()).join("chip32_legacy_sec.bin");
+
+    // 0x0000: nop
+    // 0x0002: 0x4703 (legacy Spiritualized SEC form)
+    // 0x0004: 0x4600 (exit 0)
+    fs::write(&path, [0x00, 0x00, 0x03, 0x47, 0x00, 0x46]).expect("write temp bin");
+
+    let mut cpu =
+        CPU::load_file(path.to_str().expect("temp path utf8"), None, None).expect("load temp bin");
+    run_until_halt(&mut cpu);
+
+    assert!(matches!(cpu.halt, HaltState::Success));
+    assert!(cpu.carry, "legacy 0x4703 should set carry like SEC");
+}

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, env, fs};
 
-use util::prep_and_load;
+use util::{build_and_load, prep_and_load, prep_test};
 
 mod util;
 
@@ -26,7 +26,7 @@ fn it_preserves_registers_across_reload_slots() {
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
     assert_eq!(cpu.work_regs[1], 0x1234);
 
-    cpu.restart_for_slot(2);
+    cpu.restart_for_slot(2).expect("restart for slot 2");
     run_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
@@ -39,4 +39,24 @@ fn it_preserves_registers_across_reload_slots() {
         "expected reload log entry, got {:?}",
         cpu.logs
     );
+}
+
+#[test]
+fn it_reloads_program_from_disk_for_reload_slots() {
+    let asm_path = prep_test("tests/asm/reload.asm", HashMap::new());
+    let output_path =
+        env::temp_dir().join(format!("chip32-reload-disk-{}.bin", std::process::id()));
+    let mut cpu = build_and_load(&asm_path, &output_path);
+
+    run_until_halt(&mut cpu);
+    assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
+
+    // 0x0000: nop
+    // 0x0002: 0x4601 (exit 1)
+    fs::write(&output_path, [0x00, 0x00, 0x01, 0x46]).expect("rewrite reload bin");
+
+    cpu.restart_for_slot(2).expect("restart from rewritten bin");
+    run_until_halt(&mut cpu);
+
+    assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Failure));
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -1,18 +1,8 @@
 use std::{collections::HashMap, env, fs};
 
-use util::{build_and_load, prep_and_load, prep_test};
+use util::{build_and_load, execute_until_halt, prep_and_load, prep_test};
 
 mod util;
-
-fn run_until_halt(cpu: &mut chip32_sim::cpu::CPU) {
-    for _ in 0..1_000_000 {
-        cpu.step();
-        if !matches!(cpu.halt, chip32_sim::cpu::HaltState::Running) {
-            return;
-        }
-    }
-    panic!("CPU did not halt");
-}
 
 #[test]
 fn it_preserves_registers_across_reload_slots() {
@@ -22,12 +12,12 @@ fn it_preserves_registers_across_reload_slots() {
         HashMap::new(),
     );
 
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
     assert_eq!(cpu.work_regs[1], 0x1234);
 
     cpu.restart_for_slot(2).expect("restart for slot 2");
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
     assert_eq!(cpu.work_regs[0], 2);
@@ -48,7 +38,7 @@ fn it_reloads_program_from_disk_for_reload_slots() {
         env::temp_dir().join(format!("chip32-reload-disk-{}.bin", std::process::id()));
     let mut cpu = build_and_load(&asm_path, &output_path);
 
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
 
     // 0x0000: nop
@@ -56,7 +46,7 @@ fn it_reloads_program_from_disk_for_reload_slots() {
     fs::write(&output_path, [0x00, 0x00, 0x01, 0x46]).expect("rewrite reload bin");
 
     cpu.restart_for_slot(2).expect("restart from rewritten bin");
-    run_until_halt(&mut cpu);
+    execute_until_halt(&mut cpu);
 
     assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Failure));
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use util::prep_and_load;
+
+mod util;
+
+fn run_until_halt(cpu: &mut chip32_sim::cpu::CPU) {
+    for _ in 0..1_000_000 {
+        cpu.step();
+        if !matches!(cpu.halt, chip32_sim::cpu::HaltState::Running) {
+            return;
+        }
+    }
+    panic!("CPU did not halt");
+}
+
+#[test]
+fn it_preserves_registers_across_reload_slots() {
+    let mut cpu = prep_and_load(
+        "tests/asm/reload.asm",
+        "tests/bin/reload.bin",
+        HashMap::new(),
+    );
+
+    run_until_halt(&mut cpu);
+    assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
+    assert_eq!(cpu.work_regs[1], 0x1234);
+
+    cpu.restart_for_slot(2);
+    run_until_halt(&mut cpu);
+
+    assert!(matches!(cpu.halt, chip32_sim::cpu::HaltState::Success));
+    assert_eq!(cpu.work_regs[0], 2);
+    assert_eq!(cpu.work_regs[1], 0x1234);
+    assert!(
+        cpu.logs
+            .iter()
+            .any(|log| log.contains("Restarting CHIP32 with reload slot 0x2")),
+        "expected reload log entry, got {:?}",
+        cpu.logs
+    );
+}

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -8,11 +8,22 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use chip32_sim::cpu::CPU;
+use chip32_sim::cpu::{HaltState, CPU};
 
 static NEXT_TEST_FILE_ID: AtomicUsize = AtomicUsize::new(0);
 
 // Testing
+
+pub fn execute_until_halt(cpu: &mut CPU) {
+    for _ in 0..1_000_000 {
+        cpu.step();
+        if !matches!(cpu.halt, HaltState::Running) {
+            return;
+        }
+    }
+
+    panic!("CPU did not halt");
+}
 
 pub fn test_command<TS: FnOnce(&mut CPU) -> (), TA: FnOnce(&CPU) -> ()>(
     asm_path: &str,

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,17 @@
-use std::{collections::HashMap, env, fs, process::Command};
+#![allow(dead_code)]
+
+use std::{
+    collections::HashMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use chip32_sim::cpu::CPU;
 use regex::Regex;
+
+static NEXT_TEST_FILE_ID: AtomicUsize = AtomicUsize::new(0);
 
 // Testing
 
@@ -47,11 +57,32 @@ pub fn test_command_without_setup<T: FnOnce(&CPU) -> ()>(
 
 // Loading
 
-pub fn tmp_path() -> String {
-    "tests/chip32-tmp.asm".to_string()
+fn unique_temp_path(base_path: &str) -> PathBuf {
+    let base_path = Path::new(base_path);
+    let stem = base_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("chip32");
+    let extension = base_path
+        .extension()
+        .and_then(|extension| extension.to_str());
+    let unique_id = NEXT_TEST_FILE_ID.fetch_add(1, Ordering::Relaxed);
+    let file_name = match extension {
+        Some(extension) => format!(
+            "chip32-{stem}-{}-{unique_id}.{extension}",
+            std::process::id()
+        ),
+        None => format!("chip32-{stem}-{}-{unique_id}", std::process::id()),
+    };
+
+    env::temp_dir().join(file_name)
 }
 
-pub fn prep_test(asm_path: &str, replacements: HashMap<&str, &str>) {
+pub fn tmp_path() -> PathBuf {
+    unique_temp_path("chip32-tmp.asm")
+}
+
+pub fn prep_test(asm_path: &str, replacements: HashMap<&str, &str>) -> PathBuf {
     let tmp_path = tmp_path();
 
     let mut asm = fs::read_to_string(asm_path).expect(&format!("Unable to read {asm_path}"));
@@ -63,24 +94,51 @@ pub fn prep_test(asm_path: &str, replacements: HashMap<&str, &str>) {
         asm = match_regex.replace_all(&asm, replacement).to_string();
     }
 
-    fs::write(&tmp_path, asm).expect(&format!("Unable to write to {tmp_path}"));
+    fs::write(&tmp_path, asm).expect(&format!("Unable to write to {}", tmp_path.display()));
+
+    tmp_path
 }
 
-pub fn build_and_load(asm_path: &str, output_path: &str) -> CPU {
-    let bass_path = env::var("BASS_PATH").expect("No BASS_PATH envvar found");
+pub fn build_and_load(asm_path: &Path, output_path: &Path) -> CPU {
+    let bass_path = env::var("BASS_PATH").unwrap_or_else(|_| {
+        let local_bass = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("manifest dir should have parent")
+            .join("bass-chip32")
+            .join("bass");
+        local_bass.to_string_lossy().into_owned()
+    });
 
     let output = Command::new(bass_path)
-        .args(["-strict", asm_path, "-o", output_path])
+        .args([
+            "-strict",
+            asm_path.to_str().expect("asm path should be valid utf-8"),
+            "-o",
+            output_path
+                .to_str()
+                .expect("output path should be valid utf-8"),
+        ])
         .output()
         .expect("Compilation failed");
 
     assert!(output.status.success(), "Compilation failed: {output:?}");
 
-    CPU::load_file(output_path, None, None)
-        .expect(&format!("Could not load bin file at {output_path}"))
+    CPU::load_file(
+        output_path
+            .to_str()
+            .expect("output path should be valid utf-8"),
+        None,
+        None,
+    )
+    .expect(&format!(
+        "Could not load bin file at {}",
+        output_path.display()
+    ))
 }
 
 pub fn prep_and_load(asm_path: &str, output_path: &str, replacements: HashMap<&str, &str>) -> CPU {
-    prep_test(asm_path, replacements);
-    build_and_load(&tmp_path(), output_path)
+    let asm_path = prep_test(asm_path, replacements);
+    let output_path = unique_temp_path(output_path);
+
+    build_and_load(&asm_path, &output_path)
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use chip32_sim::cpu::CPU;
-use regex::Regex;
 
 static NEXT_TEST_FILE_ID: AtomicUsize = AtomicUsize::new(0);
 
@@ -87,11 +86,8 @@ pub fn prep_test(asm_path: &str, replacements: HashMap<&str, &str>) -> PathBuf {
 
     let mut asm = fs::read_to_string(asm_path).expect(&format!("Unable to read {asm_path}"));
 
-    // TODO: This is naive
     for (original, replacement) in replacements.into_iter() {
-        let match_regex = Regex::new(&format!("\\{{{original}\\}}")).unwrap();
-
-        asm = match_regex.replace_all(&asm, replacement).to_string();
+        asm = asm.replace(&format!("{{{original}}}"), replacement);
     }
 
     fs::write(&tmp_path, asm).expect(&format!("Unable to write to {}", tmp_path.display()));


### PR DESCRIPTION
This PR improves simulator compatibility with real CHIP32 loaders and tightens the test harness around those paths.

### Changes

- treat legacy `0x4703` as `sec`
- add reload-slot restart support for JSON execution
- simulate `rset` and `uivisible` well enough for loader flows
- advance file offsets after `read`
- preserve initial RAM for reload restarts
- keep RAM heap-backed to avoid large stack frames in tests while retaining the existing 8 KiB memory model
- make test assembly/bin temp paths unique so `cargo test --all-targets` is stable
- ignore `.DS_Store`

### Tests

- `cargo fmt --check`
- `cargo test --all-targets`

### Notes

- legacy `sec` compatibility is covered by `tests/legacy_sec.rs`
- reload behavior is covered by `tests/reload.rs`